### PR TITLE
Fix GitHub Pages assets path

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
-    <link rel="icon" href="/lovable-uploads/43ef12df-459f-4ce4-9d1a-553d6fb8f11a.png" type="image/png">
+    <link rel="icon" href="lovable-uploads/43ef12df-459f-4ce4-9d1a-553d6fb8f11a.png" type="image/png">
   </head>
 
   <body>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -35,7 +35,7 @@ export default function HeroSection() {
         {/* Prova social abaixo do CTA */}
         <div className="flex items-center gap-2 mt-4 bg-green-50 border border-green-200 rounded-xl px-5 py-3 shadow-sm animate-fade-in">
           <img
-            src="/lovable-uploads/fce2c06c-846b-4c6b-9f33-6fd157d48419.png"
+            src="lovable-uploads/fce2c06c-846b-4c6b-9f33-6fd157d48419.png"
             alt="WhatsApp"
             className="w-7 h-7"
           />

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: '/dados-boost-premium/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set Vite `base` so build files work on GitHub Pages
- use relative URLs for assets
- address lint errors from no-empty-object rules
- switch tailwind plugin import to ESM

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e11b2bf788328a3be1021075d98a8